### PR TITLE
65 issue   max version set for ap

### DIFF
--- a/APWorld/outward/archipelago.json
+++ b/APWorld/outward/archipelago.json
@@ -2,6 +2,5 @@
   "game": "{{GAME}}",
   "world_version": "{{VERSION}}",
   "compatible_version": 7,
-  "minimum_ap_version": "{{ARCHIPELAGO_VERSION}}",
-  "maximum_ap_version": "{{ARCHIPELAGO_VERSION}}"
+  "minimum_ap_version": "0.6.5"
 }


### PR DESCRIPTION
Updated the Archipelago version, and removed where we specified the max ap version in the Archipelago manifest.